### PR TITLE
chore(js-plugins): upgrade core version

### DIFF
--- a/.changeset/kind-tomatoes-switch.md
+++ b/.changeset/kind-tomatoes-switch.md
@@ -1,0 +1,6 @@
+---
+"@farmfe/js-plugin-react-compiler": patch
+"@farmfe/js-plugin-babel": patch
+---
+
+chore: upgrade core version

--- a/js-plugins/babel/README.md
+++ b/js-plugins/babel/README.md
@@ -23,9 +23,9 @@ import react from "@farmfe/plugin-react";
 
 defineConfig({
   plugins: [
-    // transform by compiler, default transform `tsx`, `jsx` files
+    // transform by babel, default transform `js`, `jsx`, `ts`, `tsx` files
     babel(),
-    // transform jsx
+    // transform react
     react(),
   ],
 });
@@ -40,7 +40,7 @@ defineConfig({
 
 ```ts
 {
-    moduleTypes: ["tsx", "jsx"],
+    moduleTypes: ["js", "jsx", "ts", "tsx"],
     resolvedPaths: []
 }
 ```

--- a/js-plugins/babel/package.json
+++ b/js-plugins/babel/package.json
@@ -33,14 +33,14 @@
   },
   "devDependencies": {
     "@farmfe/cli": "^1.0.4",
-    "@farmfe/core": "^1.5.0",
+    "@farmfe/core": "^1.6.0",
     "@farmfe/js-plugin-dts": "^0.6.4",
     "@types/babel__core": "^7.20.5",
     "@types/node": "^22.7.4",
     "cross-env": "^7.0.3"
   },
   "peerDependencies": {
-    "@farmfe/core": "^1.5.0"
+    "@farmfe/core": "^1.6.0"
   },
   "files": [
     "package.json",

--- a/js-plugins/react-compiler/README.md
+++ b/js-plugins/react-compiler/README.md
@@ -23,7 +23,7 @@ import react from "@farmfe/plugin-react";
 
 defineConfig({
   plugins: [
-    // transform by compiler, default transform `tsx`, `jsx` files
+    // transform by babel & react compiler, default transform `tsx`, `jsx` files
     reactCompiler(),
     // transform jsx
     react(),

--- a/js-plugins/react-compiler/package.json
+++ b/js-plugins/react-compiler/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@babel/types": "^7.26.3",
     "@farmfe/cli": "^1.0.4",
-    "@farmfe/core": "^1.5.0",
+    "@farmfe/core": "^1.6.0",
     "@farmfe/js-plugin-babel": "workspace:*",
     "@farmfe/js-plugin-dts": "^0.6.4",
     "@types/babel__core": "^7.20.5",
@@ -47,7 +47,7 @@
     "cross-env": "^7.0.3"
   },
   "peerDependencies": {
-    "@farmfe/core": "^1.5.0"
+    "@farmfe/core": "^1.6.0"
   },
   "files": [
     "package.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       '@farmfe/core':
-        specifier: ^1.5.0
-        version: 1.5.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+        specifier: ^1.6.0
+        version: 1.6.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
       '@farmfe/js-plugin-dts':
         specifier: ^0.6.4
         version: 0.6.4
@@ -173,8 +173,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       '@farmfe/core':
-        specifier: ^1.5.0
-        version: 1.5.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+        specifier: ^1.6.0
+        version: 1.6.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
       '@farmfe/js-plugin-babel':
         specifier: workspace:*
         version: link:../babel
@@ -510,6 +510,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@farmfe/core-darwin-arm64@1.6.0':
+    resolution: {integrity: sha512-VZmfufedSWPBKhmUDOlb6Fax3FjIXpFqt4ZYuHjAyPNE2LU6A/vo7D0xTZLpvLLA9xfwEGzHSBX1epw9LxlsiA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@farmfe/core-darwin-x64@1.3.0':
     resolution: {integrity: sha512-XQ7yQ0nddlhQwBN2iky6St77UepEzlxNLmelo6AZcIUgOHTv6mzmCVNXt9giceK7acTc7q9OXmU3JaRR27FjeA==}
     engines: {node: '>= 10'}
@@ -524,6 +530,12 @@ packages:
 
   '@farmfe/core-darwin-x64@1.5.0':
     resolution: {integrity: sha512-+76xdMoWR5fDz5MHIYoQEfBBaknaTLEn4CchWQ9kEcmSzuz62FQIUGjBV7FZFW/Tz7N3MMd5eLI0UWd6IFRVrA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@farmfe/core-darwin-x64@1.6.0':
+    resolution: {integrity: sha512-VF+oStZPd9UiFoN+BRosjtE3LjbK9Hkpo2tYNa/tFXvoVtJ8qrUuivMnKN2U8176ZVohQSypthLlcDZnbbZRLg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -546,6 +558,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@farmfe/core-linux-arm64-gnu@1.6.0':
+    resolution: {integrity: sha512-zdpGYKsxfR9SWNtX/+VLADVjTAm5FQeFikQ+XNa0w4bJVC9URsd5xYYkywkMv1hU09FJu4yCDdk06Y06vOf8nQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@farmfe/core-linux-arm64-musl@1.3.0':
     resolution: {integrity: sha512-NtDl1K8X9xahsJ1d0IFn9vju6wV3yLiAuow1dFJQvuAQ17AvTZZqT66GAdoMXMInAe9HdVdQWXVwmR/vpEqmlA==}
     engines: {node: '>= 10'}
@@ -560,6 +578,12 @@ packages:
 
   '@farmfe/core-linux-arm64-musl@1.5.0':
     resolution: {integrity: sha512-doRIm1dDNmrCiHBC23I0NclmIH5VTzAaYSAo5UEFdFj1yRl5FGtG6meKRoA4rPJ7/ADNT37Wf/sli5b2Pd+FFw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@farmfe/core-linux-arm64-musl@1.6.0':
+    resolution: {integrity: sha512-J0ApBMoXQU/ts/sbyMG6Px9TT1LHkmY8jkZ1N0KRpC9sNhgjffd7DpF9N9gqaQLOfageCWMyWL80oqD6wPb3Ww==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -582,6 +606,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@farmfe/core-linux-x64-gnu@1.6.0':
+    resolution: {integrity: sha512-jDGulpgDbU1zRQHCcmknh0OdbGXxn3tigII3bfbV3YjSX45jOtcEa7+q+ArLL0HlqpCwIV6+Fypjx33kbAjwBQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@farmfe/core-linux-x64-musl@1.3.0':
     resolution: {integrity: sha512-dRrJ6aJvv/MZL3C2CI5JL6WUf0lP4zaP7keQ8v9EF4RvWs4WTx8wn9m1uSNX5YpePwvdtJcz6nTS3sF6kErPOw==}
     engines: {node: '>= 10'}
@@ -596,6 +626,12 @@ packages:
 
   '@farmfe/core-linux-x64-musl@1.5.0':
     resolution: {integrity: sha512-Hnl+xETodGGogJIjGlpx4cZNOWorkkfrk3tdWH5pbYjoRZrUINR0hrjJgCTSMYYnQqYKMiZkWnCZjSDUNlPziQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@farmfe/core-linux-x64-musl@1.6.0':
+    resolution: {integrity: sha512-3Vxzj9a10uwYcwUuHZkVRMYvi4L7BddAJ5t5gXfTq/TOz8uvEVBJFanf/76sZPmGav1+UrKP1V+OMAEJIkY1uw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -618,6 +654,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@farmfe/core-win32-arm64-msvc@1.6.0':
+    resolution: {integrity: sha512-3liF5BvnRqCL+Xc5HT4yRbsFXrS1cdlMOvZ0teLK+pzhOzbgoLawQKTf8Wz+NX+t2fPmTuVmlOrjVJEytN1Kcg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@farmfe/core-win32-ia32-msvc@1.3.0':
     resolution: {integrity: sha512-aaV9rmv5bGmVNV6T+cn7kUOFpbXiTxk1aHURadCwLXBgOie8srqDr5xbFgt4E6chEunEZ6knlTM8mQUNSVFEWQ==}
     engines: {node: '>= 10'}
@@ -632,6 +674,12 @@ packages:
 
   '@farmfe/core-win32-ia32-msvc@1.5.0':
     resolution: {integrity: sha512-CuzGmKASqLYpjCFppJs+VA3IQcSNJba9xdap2KhklaE/sCNq5yJWUTQ3CEr46IyBJkxy6WU3RsV7IHbME9n1Mw==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@farmfe/core-win32-ia32-msvc@1.6.0':
+    resolution: {integrity: sha512-IS3cgT1tvqSAsxfoZ3npQbFG3SPQX7ACpUe3gWSx+GXIqAVNsB5FM/4u9O2Ui3Fs86pwVFZb39IHVEQh82TsgQ==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -654,6 +702,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@farmfe/core-win32-x64-msvc@1.6.0':
+    resolution: {integrity: sha512-82WOrABy8P7lx10MZitj6TDVJMHDsjRarc+6gdUp/EgJQ/QGms7MoCf/KAavtwKq6qSrgGdkPgCSrCnl5WRpvw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@farmfe/core@1.3.0':
     resolution: {integrity: sha512-ELVc8z0cKkTLFNlK+BUJwtfmAB7Ym9VPtVkymqzslDnSCBi9UjBFYhNMIyx4WI2wC8aSsmAYjmlvsHlaAM+dEA==}
     engines: {node: '>=16.15.1'}
@@ -664,6 +718,10 @@ packages:
 
   '@farmfe/core@1.5.0':
     resolution: {integrity: sha512-J7zJk76n09VzbxBFumsiyAgLTksVC36Y3otbJv90xNlgQqzFQeqHIIDW0z/1ZSKOQig6ArJiEGZyzxClkweaBg==}
+    engines: {node: '>=16.15.1'}
+
+  '@farmfe/core@1.6.0':
+    resolution: {integrity: sha512-ykARCm5u0theT9jQ+JH5eVNlirBx8HadVyX4cqnoCygLpfE5kA9rFFKclE96btAqbMlPJFX/rTqiQDu9DOZjwA==}
     engines: {node: '>=16.15.1'}
 
   '@farmfe/js-plugin-dts@0.6.4':
@@ -2951,6 +3009,9 @@ snapshots:
   '@farmfe/core-darwin-arm64@1.5.0':
     optional: true
 
+  '@farmfe/core-darwin-arm64@1.6.0':
+    optional: true
+
   '@farmfe/core-darwin-x64@1.3.0':
     optional: true
 
@@ -2958,6 +3019,9 @@ snapshots:
     optional: true
 
   '@farmfe/core-darwin-x64@1.5.0':
+    optional: true
+
+  '@farmfe/core-darwin-x64@1.6.0':
     optional: true
 
   '@farmfe/core-linux-arm64-gnu@1.3.0':
@@ -2969,6 +3033,9 @@ snapshots:
   '@farmfe/core-linux-arm64-gnu@1.5.0':
     optional: true
 
+  '@farmfe/core-linux-arm64-gnu@1.6.0':
+    optional: true
+
   '@farmfe/core-linux-arm64-musl@1.3.0':
     optional: true
 
@@ -2976,6 +3043,9 @@ snapshots:
     optional: true
 
   '@farmfe/core-linux-arm64-musl@1.5.0':
+    optional: true
+
+  '@farmfe/core-linux-arm64-musl@1.6.0':
     optional: true
 
   '@farmfe/core-linux-x64-gnu@1.3.0':
@@ -2987,6 +3057,9 @@ snapshots:
   '@farmfe/core-linux-x64-gnu@1.5.0':
     optional: true
 
+  '@farmfe/core-linux-x64-gnu@1.6.0':
+    optional: true
+
   '@farmfe/core-linux-x64-musl@1.3.0':
     optional: true
 
@@ -2994,6 +3067,9 @@ snapshots:
     optional: true
 
   '@farmfe/core-linux-x64-musl@1.5.0':
+    optional: true
+
+  '@farmfe/core-linux-x64-musl@1.6.0':
     optional: true
 
   '@farmfe/core-win32-arm64-msvc@1.3.0':
@@ -3005,6 +3081,9 @@ snapshots:
   '@farmfe/core-win32-arm64-msvc@1.5.0':
     optional: true
 
+  '@farmfe/core-win32-arm64-msvc@1.6.0':
+    optional: true
+
   '@farmfe/core-win32-ia32-msvc@1.3.0':
     optional: true
 
@@ -3014,6 +3093,9 @@ snapshots:
   '@farmfe/core-win32-ia32-msvc@1.5.0':
     optional: true
 
+  '@farmfe/core-win32-ia32-msvc@1.6.0':
+    optional: true
+
   '@farmfe/core-win32-x64-msvc@1.3.0':
     optional: true
 
@@ -3021,6 +3103,9 @@ snapshots:
     optional: true
 
   '@farmfe/core-win32-x64-msvc@1.5.0':
+    optional: true
+
+  '@farmfe/core-win32-x64-msvc@1.6.0':
     optional: true
 
   '@farmfe/core@1.3.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
@@ -3151,6 +3236,50 @@ snapshots:
       '@farmfe/core-win32-arm64-msvc': 1.5.0
       '@farmfe/core-win32-ia32-msvc': 1.5.0
       '@farmfe/core-win32-x64-msvc': 1.5.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@farmfe/core@1.6.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+    dependencies:
+      '@farmfe/runtime': 0.12.10
+      '@farmfe/runtime-plugin-hmr': 3.5.10
+      '@farmfe/runtime-plugin-import-meta': 0.2.3
+      '@farmfe/utils': 0.1.0
+      '@koa/cors': 5.0.0
+      '@swc/helpers': 0.5.13
+      chokidar: 3.6.0
+      deepmerge: 4.3.1
+      dotenv: 16.4.5
+      dotenv-expand: 11.0.6
+      execa: 7.2.0
+      farm-browserslist-generator: 1.0.5
+      farm-plugin-replace-dirname: 0.2.1
+      fast-glob: 3.3.2
+      fs-extra: 11.2.0
+      http-proxy-middleware: 3.0.2
+      is-plain-object: 5.0.0
+      koa: 2.15.3
+      koa-compress: 5.1.1
+      koa-connect: 2.1.0
+      koa-static: 5.0.0
+      lodash.debounce: 4.0.8
+      loglevel: 1.9.2
+      open: 9.1.0
+      ws: 8.18.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      zod: 3.23.8
+      zod-validation-error: 1.5.0(zod@3.23.8)
+    optionalDependencies:
+      '@farmfe/core-darwin-arm64': 1.6.0
+      '@farmfe/core-darwin-x64': 1.6.0
+      '@farmfe/core-linux-arm64-gnu': 1.6.0
+      '@farmfe/core-linux-arm64-musl': 1.6.0
+      '@farmfe/core-linux-x64-gnu': 1.6.0
+      '@farmfe/core-linux-x64-musl': 1.6.0
+      '@farmfe/core-win32-arm64-msvc': 1.6.0
+      '@farmfe/core-win32-ia32-msvc': 1.6.0
+      '@farmfe/core-win32-x64-msvc': 1.6.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color


### PR DESCRIPTION
## description

The processModule hook used by the babel plugin was added in @farmfe/core@1.6.0, so need to upgrade @farmfe/core@1.6.0