### PR TITLE
fix(rust-plugins): 🐛 upate ci config to release packages

### DIFF
--- a/.changeset/shy-glasses-sparkle.md
+++ b/.changeset/shy-glasses-sparkle.md
@@ -1,5 +1,0 @@
----
-"@farmfe/plugin-wasm": patch
----
-
-Rewrite wasm plugin to parse wasm binary imports

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           fetch-depth: 2
       # - run: |
-          # git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/HEAD~1
+      # git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/HEAD~1
 
       - name: Cache rust artifacts
         uses: Swatinem/rust-cache@v2
@@ -91,11 +91,11 @@ jobs:
         if: ${{ matrix.settings.osxcross }}
         # This builds executables & sets env variables for rust to consume.
         with:
-          osx-version: '12.3'
+          osx-version: "12.3"
       - uses: goto-bus-stop/setup-zig@v2
         if: ${{ matrix.settings.zig }}
         with:
-          version: '0.13.0'
+          version: "0.13.0"
       - name: Build in docker
         uses: addnab/docker-run-action@v3
         if: ${{ matrix.settings.docker }}
@@ -189,4 +189,16 @@ jobs:
         with:
           name: ${{ github.sha }}-${{ matrix.settings.abi }}-modular-import
           path: ./rust-plugins/modular-import/npm/${{ matrix.settings.abi }}/index.farm
+          if-no-files-found: ignore
+      - name: Upload Plugin mdx
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.sha }}-${{ matrix.settings.abi }}-mdx
+          path: ./rust-plugins/mdx/npm/${{ matrix.settings.abi }}/index.farm
+          if-no-files-found: ignore
+      - name: Upload Plugin compress
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.sha }}-${{ matrix.settings.abi }}-compress
+          path: ./rust-plugins/compress/npm/${{ matrix.settings.abi }}/index.farm
           if-no-files-found: ignore

--- a/.github/workflows/release-rust-plugins.yml
+++ b/.github/workflows/release-rust-plugins.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           for abi in linux-x64-gnu linux-x64-musl darwin-x64 win32-x64-msvc linux-arm64-musl linux-arm64-gnu darwin-arm64 win32-ia32-msvc win32-arm64-msvc
           do
-            for package in dsv react-components virtual yaml strip image url icons auto-import mdx wasm worker svgr modular-import
+            for package in dsv react-components virtual yaml strip image url icons auto-import mdx wasm worker svgr modular-import compress
               do
                 folder_path="/tmp/artifacts/${{github.sha}}-${abi}-${package}"
                 if [ -d "${folder_path}" ] && [ -n "$(ls -A $folder_path)" ]; then

--- a/rust-plugins/compress/CHANGELOG.md
+++ b/rust-plugins/compress/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @farmfe/plugin-compress
+
+## 0.0.2
+
+### Patch Changes
+
+- update ci config to release packages

--- a/rust-plugins/compress/package.json
+++ b/rust-plugins/compress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-compress",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",

--- a/rust-plugins/mdx/CHANGELOG.md
+++ b/rust-plugins/mdx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-mdx
 
+## 0.0.7
+
+### Patch Changes
+
+- update ci config to release packages
+
 ## 0.0.6
 
 ### Patch Changes

--- a/rust-plugins/mdx/package.json
+++ b/rust-plugins/mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-mdx",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",

--- a/rust-plugins/wasm/CHANGELOG.md
+++ b/rust-plugins/wasm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-wasm
 
+## 0.0.8
+
+### Patch Changes
+
+- ab6a0a0: Rewrite wasm plugin to parse wasm binary imports
+
 ## 0.0.6
 
 ### Patch Changes

--- a/rust-plugins/wasm/package.json
+++ b/rust-plugins/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-wasm",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",


### PR DESCRIPTION
✅ Closes: #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved release workflows with additional artifact uploads, now supporting extended package handling.
  - Updated plugin releases: Compress is now v0.0.2, MDX is now v0.0.7, and WASM is now v0.0.8 with enhanced capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->