### PR TITLE
feat(rust-plugins): 🎸 auto import support inject at end

### DIFF
--- a/rust-plugins/auto-import/options.d.ts
+++ b/rust-plugins/auto-import/options.d.ts
@@ -46,5 +46,5 @@ export interface IPluginOptions {
   presets?: Preset[];
   include?: string[];
   exclude?: string[];
-  inject_at_end?: boolean;
+  injectAtEnd?: boolean;
 }

--- a/rust-plugins/auto-import/options.d.ts
+++ b/rust-plugins/auto-import/options.d.ts
@@ -46,4 +46,5 @@ export interface IPluginOptions {
   presets?: Preset[];
   include?: string[];
   exclude?: string[];
+  inject_at_end?: boolean;
 }

--- a/rust-plugins/auto-import/playground-react/farm.config.ts
+++ b/rust-plugins/auto-import/playground-react/farm.config.ts
@@ -20,8 +20,7 @@ export default defineConfig({
         "react-router-dom",
       ],
       dirs: ['src/apis'],
-      ignore:[],
-      injectAtEnd: true,
+      ignore:[]
     }),
     visualizer()
   ],

--- a/rust-plugins/auto-import/playground-react/farm.config.ts
+++ b/rust-plugins/auto-import/playground-react/farm.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
         "react-router-dom",
       ],
       dirs: ['src/apis'],
-      ignore:[]
+      ignore:[],
+      injectAtEnd: true,
     }),
     visualizer()
   ],

--- a/rust-plugins/auto-import/src/lib.rs
+++ b/rust-plugins/auto-import/src/lib.rs
@@ -84,6 +84,7 @@ impl Default for Dts {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct Options {
   pub dirs: Option<Vec<ConfigRegex>>,
   pub dts: Option<Dts>,

--- a/rust-plugins/auto-import/src/lib.rs
+++ b/rust-plugins/auto-import/src/lib.rs
@@ -92,6 +92,7 @@ pub struct Options {
   pub import_mode: Option<ImportMode>,
   pub include: Option<Vec<ConfigRegex>>,
   pub exclude: Option<Vec<ConfigRegex>>,
+  pub inject_at_end: Option<bool>,
 }
 
 #[farm_plugin]
@@ -157,7 +158,8 @@ impl Plugin for FarmfePluginAutoImport {
         vue_template_addon(&mut content, &imports);
       }
       let content =
-        parser::inject_imports::inject_imports(&content, imports.clone().to_vec(), None);
+        parser::inject_imports::inject_imports(&content, imports.clone().to_vec(), None, options.inject_at_end.unwrap_or(false));
+      println!("content: {}", content);
       // let (cm, src) = create_swc_source_map(Source {
       //   path: PathBuf::from(param.resolved_path),
       //   content: Arc::new(content.clone()),

--- a/rust-plugins/auto-import/src/lib.rs
+++ b/rust-plugins/auto-import/src/lib.rs
@@ -159,7 +159,6 @@ impl Plugin for FarmfePluginAutoImport {
       }
       let content =
         parser::inject_imports::inject_imports(&content, imports.clone().to_vec(), None, options.inject_at_end.unwrap_or(false));
-      println!("content: {}", content);
       // let (cm, src) = create_swc_source_map(Source {
       //   path: PathBuf::from(param.resolved_path),
       //   content: Arc::new(content.clone()),

--- a/rust-plugins/auto-import/src/parser/inject_imports.rs
+++ b/rust-plugins/auto-import/src/parser/inject_imports.rs
@@ -132,8 +132,8 @@ pub fn inject_imports(content: &str, imports: Vec<Import>, priority: Option<usiz
       })
     })
     .collect::<Vec<Import>>();
-  let inject_idx = if inject_at_end == true {
-    esm_imports.last().map_or(0, |i| i.span.hi.0) as usize
+  let inject_idx = if inject_at_end {
+    esm_imports.last().map_or(0, |i| i.span.hi.0 as usize)
   } else {
     0
   };

--- a/rust-plugins/auto-import/src/parser/inject_imports.rs
+++ b/rust-plugins/auto-import/src/parser/inject_imports.rs
@@ -54,7 +54,7 @@ fn get_exclude_imports(content: &str, imports: Vec<Import>) -> Vec<Import> {
     .collect()
 }
 
-pub fn inject_imports(content: &str, imports: Vec<Import>, priority: Option<usize>) -> String {
+pub fn inject_imports(content: &str, imports: Vec<Import>, priority: Option<usize>, inject_at_end: bool) -> String {
   let esm_imports = parse_esm_imports(None, Some(content));
   let imports = get_exclude_imports(&content, imports)
     .into_iter()
@@ -132,7 +132,14 @@ pub fn inject_imports(content: &str, imports: Vec<Import>, priority: Option<usiz
       })
     })
     .collect::<Vec<Import>>();
+  let inject_idx = if inject_at_end == true {
+    esm_imports.last().map_or(0, |i| i.span.hi.0) as usize
+  } else {
+    0
+  };
   let mut content_str = stringify_imports(imports);
-  content_str.push_str(content);
-  content_str
+  let mut content = content.to_string();
+  content.insert_str(inject_idx, &content_str);
+  // content_str.push_str(content);
+  content
 }

--- a/rust-plugins/auto-import/src/parser/parse.rs
+++ b/rust-plugins/auto-import/src/parser/parse.rs
@@ -1,8 +1,7 @@
 use std::{collections::HashMap, fs};
 
 use farmfe_core::{
-  swc_ecma_ast::*,
-  swc_ecma_parser::{Syntax, TsSyntax},
+  swc_common::Span, swc_ecma_ast::*, swc_ecma_parser::{Syntax, TsSyntax}
 };
 use farmfe_toolkit::{
   script::{parse_module, ParseScriptModuleResult},
@@ -69,6 +68,7 @@ pub struct ESMImport {
   pub namespaced_import: Option<String>,
   pub named_imports: Option<HashMap<String, String>>,
   pub type_named_imports: Option<HashMap<String, String>>,
+  pub span: Span,
 }
 
 pub struct ImportsVisitor {
@@ -124,6 +124,7 @@ impl Visit for ImportsVisitor {
                 namespaced_import: None,
                 named_imports: None,
                 type_named_imports: None,
+                span: import.span
               });
             }
             ImportSpecifier::Namespace(namespace) => {
@@ -135,6 +136,7 @@ impl Visit for ImportsVisitor {
                 default_import: None,
                 named_imports: None,
                 type_named_imports: None,
+                span: import.span
               });
             }
           }
@@ -147,6 +149,7 @@ impl Visit for ImportsVisitor {
             namespaced_import: None,
             type_named_imports: None,
             named_imports: Some(named_imports),
+            span: import.span
           });
         }
         if !type_named_imports.is_empty() {
@@ -157,6 +160,7 @@ impl Visit for ImportsVisitor {
             namespaced_import: None,
             type_named_imports: Some(type_named_imports),
             named_imports: None,
+            span: import.span
           });
         }
       }


### PR DESCRIPTION
auto import support inject at end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to control where auto-imported statements are inserted—either at the beginning or after the last existing import—via a new setting.
* **Improvements**
  * Enhanced import parsing to track the position of existing import statements, enabling more precise placement of auto-imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->