### PR TITLE
feat(rust-plugins): 🎸 release farm v2-beta

### DIFF
--- a/.changeset/brown-turkeys-clean.md
+++ b/.changeset/brown-turkeys-clean.md
@@ -1,0 +1,19 @@
+---
+"@farmfe/plugin-auto-import": major
+"@farmfe/plugin-compress": major
+"@farmfe/plugin-dsv": major
+"@farmfe/plugin-icons": major
+"@farmfe/plugin-image": major
+"@farmfe/plugin-mdx": major
+"@farmfe/plugin-modular-import": major
+"@farmfe/plugin-react-components": major
+"@farmfe/plugin-strip": major
+"@farmfe/plugin-svgr": major
+"@farmfe/plugin-url": major
+"@farmfe/plugin-virtual": major
+"@farmfe/plugin-wasm": major
+"@farmfe/plugin-worker": major
+"@farmfe/plugin-yaml": major
+---
+
+release farm v2-beta

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -27,6 +27,7 @@
     "vuetify": "0.0.0"
   },
   "changesets": [
-    "blue-crabs-fail"
+    "blue-crabs-fail",
+    "brown-turkeys-clean"
   ]
 }

--- a/.github/workflows/release-rust-plugins.yml
+++ b/.github/workflows/release-rust-plugins.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: Publish to npm
         run: |
-          npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} && npm config set access public && pnpm --filter "{rust-plugins}[HEAD~1]" publish --no-git-checks
+          npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} && npm config set access public && pnpm --filter "{rust-plugins}[HEAD~1]" publish --tag beta --no-git-checks

--- a/rust-plugins/auto-import/CHANGELOG.md
+++ b/rust-plugins/auto-import/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-auto-import
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/auto-import/package.json
+++ b/rust-plugins/auto-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-auto-import",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",

--- a/rust-plugins/compress/CHANGELOG.md
+++ b/rust-plugins/compress/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-compress
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/compress/package.json
+++ b/rust-plugins/compress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-compress",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",

--- a/rust-plugins/dsv/CHANGELOG.md
+++ b/rust-plugins/dsv/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-dsv
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/dsv/package.json
+++ b/rust-plugins/dsv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-dsv",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "private": false,
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",

--- a/rust-plugins/icons/CHANGELOG.md
+++ b/rust-plugins/icons/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-icons
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/icons/package.json
+++ b/rust-plugins/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-icons",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",

--- a/rust-plugins/image/CHANGELOG.md
+++ b/rust-plugins/image/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-image
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/image/package.json
+++ b/rust-plugins/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-image",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",

--- a/rust-plugins/mdx/CHANGELOG.md
+++ b/rust-plugins/mdx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-mdx
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/mdx/package.json
+++ b/rust-plugins/mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-mdx",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",

--- a/rust-plugins/modular-import/CHANGELOG.md
+++ b/rust-plugins/modular-import/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-modular-import
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/modular-import/package.json
+++ b/rust-plugins/modular-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-modular-import",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",

--- a/rust-plugins/react-components/CHANGELOG.md
+++ b/rust-plugins/react-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-react-components
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 1.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/react-components/package.json
+++ b/rust-plugins/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-react-components",
-  "version": "1.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "private": false,
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",

--- a/rust-plugins/strip/CHANGELOG.md
+++ b/rust-plugins/strip/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-strip
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/strip/package.json
+++ b/rust-plugins/strip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-strip",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "private": false,
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",

--- a/rust-plugins/svgr/CHANGELOG.md
+++ b/rust-plugins/svgr/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-svgr
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/svgr/package.json
+++ b/rust-plugins/svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-svgr",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",

--- a/rust-plugins/url/CHANGELOG.md
+++ b/rust-plugins/url/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-url
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/url/package.json
+++ b/rust-plugins/url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-url",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",

--- a/rust-plugins/virtual/CHANGELOG.md
+++ b/rust-plugins/virtual/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-virtual
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/virtual/package.json
+++ b/rust-plugins/virtual/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-virtual",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "private": false,
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",

--- a/rust-plugins/wasm/CHANGELOG.md
+++ b/rust-plugins/wasm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-wasm
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/wasm/package.json
+++ b/rust-plugins/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-wasm",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",

--- a/rust-plugins/worker/CHANGELOG.md
+++ b/rust-plugins/worker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-worker
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/worker/package.json
+++ b/rust-plugins/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-worker",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",

--- a/rust-plugins/yaml/CHANGELOG.md
+++ b/rust-plugins/yaml/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-yaml
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- release farm v2-beta
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/rust-plugins/yaml/package.json
+++ b/rust-plugins/yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-yaml",
-  "version": "0.1.0-beta.0",
+  "version": "2.0.0-beta.0",
   "private": false,
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped 15 @farmfe plugins to 2.0.0-beta.0 for the v2 beta release.
  - Added a changeset and updated prerelease configuration.
- Documentation
  - Added changelog entries for each plugin noting the v2 beta release.
- CI
  - Updated publish process to release rust-plugins under the npm “beta” tag.

Impacts: Users can install and test the v2 beta versions of affected plugins via the beta tag. No functional code changes included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->