### PR TITLE
fix(rust-plugins): invalid worker extension

### DIFF
--- a/.changeset/late-moles-decide.md
+++ b/.changeset/late-moles-decide.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/plugin-worker": patch
+---
+
+Fix invalid worker output extension

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -30,6 +30,7 @@
     "beige-eyes-repeat",
     "blue-crabs-fail",
     "brown-turkeys-clean",
+    "late-moles-decide",
     "tender-cats-swim"
   ]
 }

--- a/rust-plugins/worker/CHANGELOG.md
+++ b/rust-plugins/worker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farmfe/plugin-worker
 
+## 2.0.0-beta.1
+
+### Patch Changes
+
+- Fix invalid worker output extension
+
 ## 2.0.0-beta.0
 
 ### Major Changes

--- a/rust-plugins/worker/package.json
+++ b/rust-plugins/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmfe/plugin-worker",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "main": "scripts/index.js",
   "types": "scripts/index.d.ts",
   "type": "module",

--- a/rust-plugins/worker/src/lib.rs
+++ b/rust-plugins/worker/src/lib.rs
@@ -8,8 +8,8 @@ use farmfe_compiler::Compiler;
 use farmfe_core::{
   cache_item,
   config::{
-    persistent_cache::PersistentCacheConfig,
-    Config, ModuleFormat, ModuleFormatConfig, OutputConfig, TargetEnv,
+    persistent_cache::PersistentCacheConfig, Config, ModuleFormat, ModuleFormatConfig,
+    OutputConfig, TargetEnv,
   },
   context::{CompilationContext, EmitFileParams},
   deserialize,
@@ -76,6 +76,7 @@ fn build_worker(
       persistent_cache: Box::new(PersistentCacheConfig::Bool(false)),
       output: Box::new(OutputConfig {
         target_env: TargetEnv::Library,
+        entry_filename: full_file_name.clone(),
         ..*compiler_config.output.clone()
       }),
       lazy_compilation: false,
@@ -87,8 +88,7 @@ fn build_worker(
   .unwrap();
   compiler.compile().unwrap();
   let resources_map = compiler.context().resources_map.lock();
-  let resource_name = format!("{}.mjs", full_file_name);
-  let resource = resources_map.get(&resource_name).unwrap();
+  let resource = resources_map.get(&full_file_name).unwrap();
   let content_bytes = resource.bytes.clone();
   content_bytes
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Corrected worker output file extension for proper handling.
  - Ensured entry filename is correctly set in worker output.
  - Improved worker resource resolution to avoid missing outputs.
- Documentation
  - Updated changelog with 2.0.0-beta.1 patch details.
- Chores
  - Prepared release via changeset updates.
  - Bumped worker plugin version to 2.0.0-beta.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->