### PR TITLE
chore(rust-plugins): update farm crates

### DIFF
--- a/.github/workflows/release-changeset.yml
+++ b/.github/workflows/release-changeset.yml
@@ -118,7 +118,7 @@ jobs:
         id: changesets-rust-main
         uses: changesets/action@v1
         with:
-          publish: pnpm exec changeset publish --tag beta
+          publish: pnpm exec changeset publish
           title: "Release: Rust Plugins (Beta)"
           commit: "chore: release rust plugins (beta)"
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,7 +855,7 @@ dependencies = [
  "farmfe_macro_plugin",
  "farmfe_toolkit",
  "farmfe_toolkit_plugin_types",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "globset",
  "serde",
  "serde_json",
@@ -865,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "farmfe_compiler"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cffd52a87c42958b1d5934c287bc61a087cad26abcbc5ec547a315e42ede22b"
+checksum = "d9cc76d67a0e4be6b3dfbbc4f4767eba086b33eee684afac0871ae38e37008d3"
 dependencies = [
  "enhanced-magic-string",
  "farmfe_core",
@@ -892,21 +892,21 @@ dependencies = [
  "farmfe_testing",
  "farmfe_testing_helpers",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "sourcemap 9.2.2",
 ]
 
 [[package]]
 name = "farmfe_core"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5854653a4ec63cbe363159295c6b13198698ae795f8e0933c2a5f9051f1dae2f"
+checksum = "b3a719752414a1303ca86de127e61024fc54dfe64d01faba782d879d87d0843d"
 dependencies = [
  "blake2",
  "dashmap 6.1.0",
  "downcast-rs",
  "farmfe_macro_cache_item",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "globset",
  "heck 0.5.0",
  "hex",
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "farmfe_macro_cache_item"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47de322bb6e3c5a4df3ee38f409e0174021855a30d541e2ade9e7b082986a344"
+checksum = "bf179f567f72a3828f74aff319c1150cdb3335029bfc125ff65774b476e8e502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -963,7 +963,7 @@ dependencies = [
  "farmfe_macro_plugin",
  "farmfe_toolkit",
  "farmfe_toolkit_plugin_types",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "glob",
  "regress",
  "serde",
@@ -986,27 +986,27 @@ dependencies = [
 
 [[package]]
 name = "farmfe_plugin_css"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e21dbc5527cbb12d915e363eefa4e2415ba92b644c1d7528b509c28e1a84f8"
+checksum = "2f6a35d61e67fa7d1db30768313b8a57d9ee3330986bae0ce195c7c30a0d7384"
 dependencies = [
  "farmfe_core",
  "farmfe_macro_cache_item",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "rkyv",
 ]
 
 [[package]]
 name = "farmfe_plugin_define"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49afa2c20ed0e10ac2fbacf3207323f5228888f610607eade4b71f4231cb09a9"
+checksum = "7cc5c88d437782af2defbab8b623e7697c3db2ed412399eb3c37ba2b2113fc2f"
 dependencies = [
  "farmfe_core",
  "farmfe_testing_helpers",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
 ]
 
 [[package]]
@@ -1024,16 +1024,16 @@ dependencies = [
 
 [[package]]
 name = "farmfe_plugin_file_size"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0671e698be9f9496d32399b59f39559270b662a714255fa246c42c39f24c626b"
+checksum = "11b5aa41e995d6c4689634a1fbfd124e99ed8ec06207f00618e5c6da83941ecc"
 dependencies = [
  "colored",
  "farmfe_core",
  "farmfe_macro_plugin",
  "farmfe_testing_helpers",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "flate2",
  "once_cell",
  "unicode-width 0.2.1",
@@ -1041,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "farmfe_plugin_html"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2211076cb8840c31a310cefe2164e5dfee6c0107f911276f06e1be6fbe9f0664"
+checksum = "474ecc48edf9a5cb226322b61ee922fe8d2833c6f641d7a7b321dd19586e5db1"
 dependencies = [
  "farmfe_core",
  "farmfe_testing_helpers",
@@ -1061,7 +1061,7 @@ dependencies = [
  "farmfe_macro_plugin",
  "farmfe_toolkit",
  "farmfe_toolkit_plugin_types",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "fervid",
  "loading",
  "once_cell",
@@ -1090,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "farmfe_plugin_json"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe5d900f1ac6446a8ee48f4162cb2ad8d1e310c245f9339c5b4f5a642617fa3"
+checksum = "544c9231514cd73f898a89db2f36b0df7d61037b5ef22b55388e04930e663c59"
 dependencies = [
  "farmfe_core",
  "farmfe_testing_helpers",
@@ -1101,38 +1101,38 @@ dependencies = [
 
 [[package]]
 name = "farmfe_plugin_lazy_compilation"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f57336e44dfb03a97ec19d849433c370088add801c6cc4c2557c4d87559250a7"
+checksum = "cdb41791bc8f70d8c095ca093b5d6ab18d8daa59e0902f8a007ad3ad085a957b"
 dependencies = [
  "farmfe_core",
  "farmfe_testing_helpers",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
 ]
 
 [[package]]
 name = "farmfe_plugin_library"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e2809c0cc20a9bef1e181d55426a724263cb57143433e5f73c2e1e9b5a5b1d"
+checksum = "cb100f10233ada37e511a91132713b8f43fa780b9ab36e97e0f5f81777edb8ad"
 dependencies = [
  "farmfe_core",
  "farmfe_testing_helpers",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
 ]
 
 [[package]]
 name = "farmfe_plugin_mangle_exports"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd9e7f92586806d25e481a8502fc145e4c4014865ed94e448c2ea425f8905b5"
+checksum = "968dc1b733d3278f004a40fe7b3ca5b172a2e76ab1ce995aa11fe00d25b7845a"
 dependencies = [
  "farmfe_core",
  "farmfe_testing_helpers",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
 ]
 
 [[package]]
@@ -1149,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "farmfe_plugin_minify"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec53212656edf7ca5742fcb643d5ffb6295264d38f7aa3ee811dd904014cab6"
+checksum = "9cc0863f2e8fb65f4cf4c5a621a81b164c983a9b1933179d84dfa557e5edd926"
 dependencies = [
  "farmfe_core",
  "farmfe_testing_helpers",
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "farmfe_plugin_partial_bundling"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a6be314e7d043ed96ff44ccbbf121f6b9a2f7850bb6aa061df444d93b5965d"
+checksum = "5621ae9eea42496ec30b1857d7db4908d1cfdeda94398653b415e1a1e19d27df"
 dependencies = [
  "farmfe_core",
  "farmfe_testing_helpers",
@@ -1183,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "farmfe_plugin_polyfill"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ce8135a9b27055624c5ca6fe250cce3a4b992e886ce501abf0e3af42394f65"
+checksum = "c03e70c4699a05fba71d94f9ae39571e838ba5ec5211e1d63d234a1b4ee12d03"
 dependencies = [
  "farmfe_core",
  "farmfe_testing_helpers",
@@ -1194,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "farmfe_plugin_progress"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574751dcae18f6b0e5806151547ff4174e472177427be17fad5e2aa62e250a8a"
+checksum = "e4532b2127e2e700c4eb2730113998911dcf2a15994d38f5cdb7f515640c6d36"
 dependencies = [
  "console",
  "farmfe_core",
@@ -1212,7 +1212,7 @@ dependencies = [
  "farmfe_macro_plugin",
  "farmfe_toolkit",
  "farmfe_toolkit_plugin_types",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "glob",
  "rustc-hash 2.1.1",
  "serde",
@@ -1221,67 +1221,69 @@ dependencies = [
 
 [[package]]
 name = "farmfe_plugin_resolve"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e2e31052f534c465cc75d9671c129002357c286112097877b1235ca819bad4"
+checksum = "70a82e445ffc7c65ffc64e7674e079ce30d12d9a1e4ec15fd134112130944154"
 dependencies = [
  "farmfe_core",
  "farmfe_testing_helpers",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "once_cell",
 ]
 
 [[package]]
 name = "farmfe_plugin_runtime"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fc6169daf163d797ebc9deafefa10c1a656bba97cef6c849ba17c4346cdd90"
+checksum = "1883e57abe232c5de27e415be82b7c34a92ecd3fbbb085101d49cc7c33224702"
 dependencies = [
  "enhanced-magic-string",
  "farmfe_core",
  "farmfe_testing_helpers",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "rkyv",
  "sourcemap 9.2.2",
 ]
 
 [[package]]
 name = "farmfe_plugin_script"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df285c6d10b67a9bd81b0c8681d3b78c02c91febbe6713c796822b302c757e14"
+checksum = "0437374ce79a6ba0596f28467b178281291b043cece40ddf1bc8423951ce28da"
 dependencies = [
  "farmfe_core",
+ "farmfe_plugin_script_meta",
  "farmfe_swc_transformer_import_glob",
+ "farmfe_testing_helpers",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
 ]
 
 [[package]]
 name = "farmfe_plugin_script_meta"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b80f7f10d9017d47fd396bbc927c098510a09e0d63404a440b667a5f969808a3"
+checksum = "7727385e6dfbe5c2a2ec2c80de50862488527737dcf6032545edb1074ff75de0"
 dependencies = [
  "farmfe_core",
  "farmfe_testing_helpers",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
 ]
 
 [[package]]
 name = "farmfe_plugin_static_assets"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d0ba748aa38752ab2fbfe316a4042cffb017bfeb166383743e2c0bcfce591a"
+checksum = "91d31e05da9c2176838a75964cc3c82482ddbd6c2d22a1c338217b58943630d6"
 dependencies = [
  "base64 0.21.7",
  "farmfe_core",
  "farmfe_testing_helpers",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "mime_guess",
  "rkyv",
 ]
@@ -1300,14 +1302,14 @@ dependencies = [
 
 [[package]]
 name = "farmfe_plugin_tree_shake"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806ac6410dca02c0335d59af82204ba41fdbaeeac055b7cb8fcc87c40e4ade62"
+checksum = "0f84ff12ba05004865d8208619dd5e65ad56919b4972b93343560ba225aa6524"
 dependencies = [
  "farmfe_core",
  "farmfe_testing_helpers",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
 ]
 
 [[package]]
@@ -1319,7 +1321,7 @@ dependencies = [
  "farmfe_macro_plugin",
  "farmfe_toolkit",
  "farmfe_toolkit_plugin_types",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "lazy_static",
  "mime_guess",
  "serde",
@@ -1359,7 +1361,7 @@ dependencies = [
  "farmfe_macro_plugin",
  "farmfe_toolkit",
  "farmfe_toolkit_plugin_types",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "regress",
  "rkyv",
  "rustc-hash 2.1.1",
@@ -1382,14 +1384,14 @@ dependencies = [
 
 [[package]]
 name = "farmfe_swc_transformer_import_glob"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33717571b9be3360980879ed1f9ad57c89607d7ac12b728c3294309d6687e179"
+checksum = "c443c93dc780fbdf80753bc4f26d6a69513faae2e1e83298ed180a439ec0eaad"
 dependencies = [
  "farmfe_core",
  "farmfe_testing_helpers",
  "farmfe_toolkit",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
 ]
 
 [[package]]
@@ -1409,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "farmfe_testing_helpers"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b32737facbb0d87f88bc16d9afc4f05f19c9974590bbd2498e66d7695f714b"
+checksum = "15b7b9ee4b0023bb7aa56788e8d64de9db1f88480d04a61e329608d0bf43fc4b"
 dependencies = [
  "farmfe_core",
  "insta",
@@ -1419,15 +1421,15 @@ dependencies = [
 
 [[package]]
 name = "farmfe_toolkit"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11e77c138ef96bf3a872e90da40959a5cf2f5e508299211ae828fe2320cbd8a"
+checksum = "bcae290fd8a64bad3c575015f133cfddb39a711820fe27b65492025985b4e913"
 dependencies = [
  "anyhow",
  "bytes-str",
  "farmfe_core",
  "farmfe_testing_helpers",
- "farmfe_utils 2.0.0",
+ "farmfe_utils 2.1.0",
  "itertools 0.14.0",
  "par-core",
  "preset_env_base",
@@ -1457,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "farmfe_toolkit_plugin_types"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13916fcd71323102e3b785a52b225eff411cf04a151c4f8d167c5c23c4a74032"
+checksum = "748e343cc094ab1e6ccb359aaab2ca8793bf606f45eeccc257830270755a9f6d"
 dependencies = [
  "farmfe_core",
  "lazy_static",
@@ -1479,12 +1481,13 @@ dependencies = [
 
 [[package]]
 name = "farmfe_utils"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0278f43808d96ba935379475b90d3cca0cc4a38510f754ecdec2ddaaec33db8"
+checksum = "e41a6d0041d580561a674d563ec0ea0f8255c7f534b13906e685ac14f72fb725"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "nanoid",
  "pathdiff",
  "rkyv",
  "sha2",
@@ -2517,6 +2520,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3039,6 +3051,8 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3048,8 +3062,18 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3067,6 +3091,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "rand_core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,10 @@
 [workspace]
-members = [
-  "rust-plugins/*",
-]
+members = ["rust-plugins/*"]
 resolver = "2"
 [workspace.dependencies]
-farmfe_core = { version = "2.0.0" }
-farmfe_utils = { version = "2.0.0" }
-farmfe_toolkit_plugin_types = { version = "2.0.0" }
+farmfe_core = { version = "2.1.0" }
+farmfe_utils = { version = "2.1.0" }
+farmfe_toolkit_plugin_types = { version = "2.0.1" }
 farmfe_macro_plugin = { version = "2.0.0" }
-farmfe_toolkit = "2.0.0"
-farmfe_compiler = { version = "2.0.0" }
+farmfe_toolkit = "2.1.0"
+farmfe_compiler = { version = "2.1.0" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Release pipeline now publishes without a beta tag, aligning main releases to the default channel and simplifying distribution.
  - Updated Rust workspace dependencies to newer minor versions (core, utils, toolkit, compiler) to inherit upstream fixes and improvements.
  - This may result in packages previously tagged beta being promoted to general availability.
  - No API changes; behavior should remain compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->